### PR TITLE
Ensure there is always an id attribute for singular fields.

### DIFF
--- a/src/View/BaseInput.php
+++ b/src/View/BaseInput.php
@@ -1,0 +1,27 @@
+<?php declare( strict_types=1 ); # -*- coding: utf-8 -*-
+
+namespace ChriCo\Fields\View;
+
+use ChriCo\Fields\Element\ElementInterface;
+
+abstract class BaseInput implements RenderableElementInterface {
+
+	use AttributeFormatterTrait;
+
+	/**
+	 * Prepare attributes for output on the input.
+	 *
+	 * @param array            $attributes
+	 * @param ElementInterface $element
+	 * @param string           $context
+	 *
+	 * @return array $prepared_attributes
+	 */
+	public function prepare_attributes( array $attributes, ElementInterface $element, string $context = 'default' ) {
+		if ( ! isset ( $attributes[ 'id' ] ) ) {
+			$attributes[ 'id' ] = $element->get_id();
+		}
+
+		return $attributes;
+	}
+}

--- a/src/View/Checkbox.php
+++ b/src/View/Checkbox.php
@@ -6,9 +6,7 @@ use ChriCo\Fields\Element\ChoiceElementInterface;
 use ChriCo\Fields\Element\ElementInterface;
 use ChriCo\Fields\Exception\InvalidClassException;
 
-class Checkbox implements RenderableElementInterface {
-
-	use AttributeFormatterTrait;
+class Checkbox extends BaseInput {
 
 	public function render( ElementInterface $element ): string {
 
@@ -34,16 +32,13 @@ class Checkbox implements RenderableElementInterface {
 
 		$is_multi_choice = FALSE;
 		if ( count( $choices ) > 1 ) {
-			$attributes[ 'name' ] = $element->get_name() . '[]';
-			$is_multi_choice      = TRUE;
+			$is_multi_choice = TRUE;
 		}
 
 		foreach ( $choices as $key => $name ) {
-			$element_attr = $attributes;
+			$context = $is_multi_choice ? $key : 'default';
 
-			$element_attr[ 'id' ] = $is_multi_choice
-				? $element->get_id() . '_' . $key
-				: $element->get_id();
+			$element_attr = $this->prepare_attributes( $attributes, $element, $context );
 
 			$element_attr[ 'value' ] = $key;
 
@@ -65,5 +60,16 @@ class Checkbox implements RenderableElementInterface {
 		}
 
 		return implode( '', $html );
+	}
+
+	public function prepare_attributes( array $attributes, ElementInterface $element, string $context = 'default' ) {
+		$attributes = parent::prepare_attributes( $attributes, $element, $context );
+
+		if ( 'default' !== $context ) {
+			$attributes[ 'id' ]   .= '_' . $context;
+			$attributes[ 'name' ] .= '[]';
+		}
+
+		return $attributes;
 	}
 }

--- a/src/View/Input.php
+++ b/src/View/Input.php
@@ -11,6 +11,9 @@ class Input implements RenderableElementInterface {
 	public function render( ElementInterface $element ): string {
 
 		$attributes = $element->get_attributes();
+		if ( ! isset ( $attributes[ 'id' ] ) ) {
+			$attributes[ 'id' ] = $element->get_id();
+		}
 
 		return sprintf(
 			'<input %s />',

--- a/src/View/Input.php
+++ b/src/View/Input.php
@@ -4,16 +4,12 @@ namespace ChriCo\Fields\View;
 
 use ChriCo\Fields\Element\ElementInterface;
 
-class Input implements RenderableElementInterface {
-
-	use AttributeFormatterTrait;
+class Input extends BaseInput {
 
 	public function render( ElementInterface $element ): string {
 
 		$attributes = $element->get_attributes();
-		if ( ! isset ( $attributes[ 'id' ] ) ) {
-			$attributes[ 'id' ] = $element->get_id();
-		}
+		$attributes = $this->prepare_attributes( $attributes, $element );
 
 		return sprintf(
 			'<input %s />',

--- a/src/View/Progress.php
+++ b/src/View/Progress.php
@@ -4,16 +4,12 @@ namespace ChriCo\Fields\View;
 
 use ChriCo\Fields\Element\ElementInterface;
 
-class Progress implements RenderableElementInterface {
-
-	use AttributeFormatterTrait;
+class Progress extends BaseInput {
 
 	public function render( ElementInterface $element ): string {
 
 		$attributes = $element->get_attributes();
-		if ( ! isset ( $attributes[ 'id' ] ) ) {
-			$attributes[ 'id' ] = $element->get_id();
-		}
+		$attributes = $this->prepare_attributes( $attributes, $element );
 
 		return sprintf(
 			'<progress %s>%s</progress>',

--- a/src/View/Progress.php
+++ b/src/View/Progress.php
@@ -11,6 +11,9 @@ class Progress implements RenderableElementInterface {
 	public function render( ElementInterface $element ): string {
 
 		$attributes = $element->get_attributes();
+		if ( ! isset ( $attributes[ 'id' ] ) ) {
+			$attributes[ 'id' ] = $element->get_id();
+		}
 
 		return sprintf(
 			'<progress %s>%s</progress>',

--- a/src/View/Radio.php
+++ b/src/View/Radio.php
@@ -6,9 +6,7 @@ use ChriCo\Fields\Element\ChoiceElementInterface;
 use ChriCo\Fields\Element\ElementInterface;
 use ChriCo\Fields\Exception\InvalidClassException;
 
-class Radio implements RenderableElementInterface {
-
-	use AttributeFormatterTrait;
+class Radio extends BaseInput {
 
 	public function render( ElementInterface $element ): string {
 
@@ -29,23 +27,34 @@ class Radio implements RenderableElementInterface {
 		$html = [];
 
 		foreach ( $choices as $key => $name ) {
-			$attributes[ 'id' ]    = $element->get_id() . '_' . $key;
-			$attributes[ 'value' ] = $key;
+			$element_attr = $this->prepare_attributes( $attributes, $element, $key );
+
+			$element_attr[ 'value' ] = $key;
 
 			$label = sprintf(
 				'<label for="%s">%s</label>',
-				$this->esc_attr( $attributes[ 'id' ] ),
+				$this->esc_attr( $element_attr[ 'id' ] ),
 				$this->esc_html( $name )
 			);
 
 			$html[] = sprintf(
 				'<p><input %s %s /> %s</p>',
-				$this->get_attributes_as_string( $attributes ),
+				$this->get_attributes_as_string( $element_attr ),
 				isset( $selected[ $key ] ) ? 'checked="checked"' : '',
 				$label
 			);
 		}
 
 		return implode( ' ', $html );
+	}
+
+	public function prepare_attributes( array $attributes, ElementInterface $element, string $context = 'default' ) {
+		$attributes = parent::prepare_attributes( $attributes, $element, $context );
+
+		if ( 'default' !== $context ) {
+			$attributes[ 'id' ]   .= '_' . $context;
+		}
+
+		return $attributes;
 	}
 }

--- a/src/View/Select.php
+++ b/src/View/Select.php
@@ -24,6 +24,10 @@ class Select implements RenderableElementInterface {
 		}
 
 		$attributes = $element->get_attributes();
+		if ( ! isset ( $attributes[ 'id' ] ) ) {
+			$attributes[ 'id' ] = $element->get_id();
+		}
+
 		unset( $attributes[ 'type' ], $attributes[ 'value' ] );
 
 		return sprintf(

--- a/src/View/Select.php
+++ b/src/View/Select.php
@@ -7,9 +7,7 @@ use ChriCo\Fields\Element\ChoiceElementInterface;
 use ChriCo\Fields\Element\ElementInterface;
 use ChriCo\Fields\Exception\InvalidClassException;
 
-class Select implements RenderableElementInterface {
-
-	use AttributeFormatterTrait;
+class Select extends BaseInput {
 
 	public function render( ElementInterface $element ): string {
 
@@ -24,17 +22,21 @@ class Select implements RenderableElementInterface {
 		}
 
 		$attributes = $element->get_attributes();
-		if ( ! isset ( $attributes[ 'id' ] ) ) {
-			$attributes[ 'id' ] = $element->get_id();
-		}
-
-		unset( $attributes[ 'type' ], $attributes[ 'value' ] );
+		$attributes = $this->prepare_attributes( $attributes, $element );
 
 		return sprintf(
 			'<select %s>%s</select>',
 			$this->get_attributes_as_string( $attributes ),
 			$this->render_choices( $element->get_choices(), $element->get_value() )
 		);
+	}
+
+	public function prepare_attributes( array $attributes, ElementInterface $element, string $context = 'default' ) {
+		$attributes = parent::prepare_attributes( $attributes, $element, $context );
+
+		unset( $attributes[ 'type' ], $attributes[ 'value' ] );
+
+		return $attributes;
 	}
 
 	/**

--- a/src/View/Textarea.php
+++ b/src/View/Textarea.php
@@ -4,23 +4,25 @@ namespace ChriCo\Fields\View;
 
 use ChriCo\Fields\Element\ElementInterface;
 
-class Textarea implements RenderableElementInterface {
-
-	use AttributeFormatterTrait;
+class Textarea extends BaseInput {
 
 	public function render( ElementInterface $element ): string {
 
 		$attributes = $element->get_attributes();
-		if ( ! isset ( $attributes[ 'id' ] ) ) {
-			$attributes[ 'id' ] = $element->get_id();
-		}
-
-		unset( $attributes[ 'value' ] );
+		$attributes = $this->prepare_attributes( $attributes, $element );
 
 		return sprintf(
 			'<textarea %s>%s</textarea>',
 			$this->get_attributes_as_string( $attributes ),
 			$this->esc_html( $element->get_value() )
 		);
+	}
+
+	public function prepare_attributes( array $attributes, ElementInterface $element, string $context = 'default' ) {
+		$attributes = parent::prepare_attributes( $attributes, $element, $context );
+
+		unset( $attributes[ 'type' ], $attributes[ 'value' ] );
+
+		return $attributes;
 	}
 }

--- a/src/View/Textarea.php
+++ b/src/View/Textarea.php
@@ -11,6 +11,10 @@ class Textarea implements RenderableElementInterface {
 	public function render( ElementInterface $element ): string {
 
 		$attributes = $element->get_attributes();
+		if ( ! isset ( $attributes[ 'id' ] ) ) {
+			$attributes[ 'id' ] = $element->get_id();
+		}
+
 		unset( $attributes[ 'value' ] );
 
 		return sprintf(

--- a/tests/phpunit/Unit/View/InputTest.php
+++ b/tests/phpunit/Unit/View/InputTest.php
@@ -27,6 +27,7 @@ class InputTest extends AbstractViewTestCase {
 
 		$output = ( new Input() )->render( $element );
 		static::assertContains( '<input', $output );
+		static::assertContains( 'id="foo"', $output );
 		static::assertContains( 'name="foo"', $output );
 		static::assertContains( 'type="text"', $output );
 		static::assertContains( '/>', $output );

--- a/tests/phpunit/Unit/View/ProgressTest.php
+++ b/tests/phpunit/Unit/View/ProgressTest.php
@@ -27,6 +27,7 @@ class ProgressTest extends AbstractViewTestCase {
 
 		$output = ( new Progress() )->render( $element );
 		static::assertContains( '</progress>', $output );
+		static::assertContains( 'id="foo"', $output );
 		static::assertContains( 'name="foo"', $output );
 		static::assertContains( '>100</progress>', $output );
 	}

--- a/tests/phpunit/Unit/View/SelectTest.php
+++ b/tests/phpunit/Unit/View/SelectTest.php
@@ -54,7 +54,7 @@ class SelectTest extends AbstractViewTestCase {
 	public function test_render__no_choices() {
 
 		$element = $this->get_element( 'element', new ArrayChoiceList( [] ) );
-		static::assertSame( '<select name="element"></select>', ( new Select() )->render( $element ) );
+		static::assertSame( '<select name="element" id="element"></select>', ( new Select() )->render( $element ) );
 	}
 
 	/**
@@ -67,6 +67,7 @@ class SelectTest extends AbstractViewTestCase {
 		$rendered = ( new Select() )->render( $element );
 
 		static::assertContains( '<select', $rendered );
+		static::assertContains( 'id="element"', $rendered );
 		static::assertContains( 'name="element"', $rendered );
 
 		static::assertContains( '<option', $rendered );
@@ -97,6 +98,7 @@ class SelectTest extends AbstractViewTestCase {
 
 		$rendered = ( new Select() )->render( $element );
 		static::assertContains( '<select', $rendered );
+		static::assertContains( 'id="element"', $rendered );
 		static::assertContains( 'name="element"', $rendered );
 
 		// First element

--- a/tests/phpunit/Unit/View/TextareaTest.php
+++ b/tests/phpunit/Unit/View/TextareaTest.php
@@ -27,6 +27,7 @@ class TextareaTest extends AbstractViewTestCase {
 
 		$output = ( new Textarea() )->render( $element );
 		static::assertContains( '<textarea', $output );
+		static::assertContains( 'id="foo"', $output );
 		static::assertContains( 'name="foo"', $output );
 		static::assertContains( '>100</textarea>', $output );
 	}


### PR DESCRIPTION
The `Label` view class currently ensures that a `for` attribute is set. Which completely makes sense, however only if an `id` attribute is set for the input as well.

This PR enforces the `id` attribute to be set on singular input fields where this was previously not the case. This makes it simple for developers as they only need to provide the `name` attribute (if they're lazy 🙂 ).

Additional observation: The `Label`'s `for` attribute and even the entire label tag itself do not make sense for "multi-field" views such as `Radio` or `Checkbox`. The fields displayed there have distinct IDs (which they rightfully need to), but the label still references the general ID, for which no actual input tag exists. This causes accessibility issues. I'm happy to explore possibilities there as well, but it should be a separate ticket/PR.