### PR TITLE
Add support for props through boolean attributes.

### DIFF
--- a/src/Element/ElementInterface.php
+++ b/src/Element/ElementInterface.php
@@ -52,15 +52,15 @@ interface ElementInterface {
 	public function set_attributes( array $attributes = [] );
 
 	/**
-	 * @param string     $key
-	 * @param int|string $value
+	 * @param string          $key
+	 * @param int|string|bool $value
 	 */
 	public function set_attribute( string $key, $value );
 
 	/**
 	 * @param string $key
 	 *
-	 * @return int|string $value
+	 * @return int|string|bool $value
 	 */
 	public function get_attribute( string $key );
 

--- a/src/View/AttributeFormatterTrait.php
+++ b/src/View/AttributeFormatterTrait.php
@@ -15,6 +15,13 @@ trait AttributeFormatterTrait {
 
 		$html = [];
 		foreach ( $attributes as $key => $value ) {
+			if ( is_bool( $value ) ) {
+				if ( $value ) {
+					$html[] = $this->esc_attr( $key );
+				}
+				continue;
+			}
+
 			if ( is_array( $value ) ) {
 				$value = json_encode( $value );
 			}


### PR DESCRIPTION
There are not only attributes which are printed as `key="value"`, but also props which should be printed simply as `key` (for example `required` or `disabled`).

This PR adds support for props by allowing them to be specified as attributes with boolean values. If the value is true, the prop is printed, otherwise it is excluded.