### PR TITLE
Extended boolean attributes and disabled elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
 
+## 0.2.0 (NOT RELEASED)
+- Added new tests for `AttributeFormatterTrait`.
+- Implemented boolean-attributes like `disabled` or `required`.
+- Introduced new method `is_disabled` to `ElementInterface`.
+- Don't bind data to Elements or validate Elements which are disabled. 
+
 ## 0.1.0
 - First release

--- a/src/Element/BaseElement.php
+++ b/src/Element/BaseElement.php
@@ -108,4 +108,10 @@ abstract class BaseElement implements ElementInterface {
 		return $this->options[ $key ];
 	}
 
+	public function is_disabled(): bool {
+
+		$disabled = $this->get_attribute( 'disabled' );
+
+		return is_bool( $disabled ) && $disabled;
+	}
 }

--- a/src/Element/ElementInterface.php
+++ b/src/Element/ElementInterface.php
@@ -90,4 +90,9 @@ interface ElementInterface {
 	 * @return int|string $value
 	 */
 	public function get_option( string $key );
+
+	/**
+	 * @return bool
+	 */
+	public function is_disabled(): bool;
 }

--- a/src/Element/Form.php
+++ b/src/Element/Form.php
@@ -66,10 +66,14 @@ class Form extends CollectionElement implements FormInterface {
 	public function set_data( array $input_data = [] ) {
 
 		foreach ( $input_data as $name => $value ) {
-			if ( $this->has_element( $name ) ) {
-				$this->get_element( $name )
-					->set_value( $value );
+			if ( ! $this->has_element( $name ) ) {
+				continue;
 			}
+			$element = $this->get_element( $name );
+			if ( $element->is_disabled() ) {
+				continue;
+			}
+			$element->set_value( $value );
 		}
 	}
 
@@ -83,7 +87,12 @@ class Form extends CollectionElement implements FormInterface {
 				continue;
 			}
 
-			$element                 = $this->get_element( $name );
+			$element = $this->get_element( $name );
+
+			if ( $element->is_disabled() ) {
+				continue;
+			}
+
 			$this->raw_data[ $name ] = $value;
 			$value                   = $this->filter( $name, $value );
 			$this->data[ $name ]     = $value;
@@ -124,6 +133,16 @@ class Form extends CollectionElement implements FormInterface {
 		$this->is_valid = TRUE;
 
 		foreach ( $this->data as $name => $data ) {
+
+			// only validate data where an element exists
+			// ... or ...
+			// the element is not disabled.
+			if ( ! $this->has_element( $name )
+				|| $this->get_element( $name )
+					->is_disabled() ) {
+				continue;
+			}
+
 			if ( ! $this->validate( $name, $data ) ) {
 				$this->is_valid = FALSE;
 				break;
@@ -154,7 +173,7 @@ class Form extends CollectionElement implements FormInterface {
 		$is_valid = TRUE;
 		foreach ( $this->validators[ $name ] as $validator ) {
 			if ( ! $validator->is_valid( $value ) ) {
-				$errors = array_merge( $errors, $validator->get_error_messages() );
+				$errors   = array_merge( $errors, $validator->get_error_messages() );
 				$is_valid = FALSE;
 			}
 		}

--- a/src/View/AttributeFormatterTrait.php
+++ b/src/View/AttributeFormatterTrait.php
@@ -15,21 +15,22 @@ trait AttributeFormatterTrait {
 
 		$html = [];
 		foreach ( $attributes as $key => $value ) {
+
 			if ( is_bool( $value ) ) {
 				if ( $value ) {
 					$html[] = $this->esc_attr( $key );
 				}
-				continue;
-			}
+			} else {
 
-			if ( is_array( $value ) ) {
-				$value = json_encode( $value );
+				if ( is_array( $value ) ) {
+					$value = json_encode( $value );
+				}
+				$html[] = sprintf(
+					'%s="%s"',
+					$this->esc_attr( $key ),
+					$this->esc_attr( $value )
+				);
 			}
-			$html[] = sprintf(
-				'%s="%s"',
-				$this->esc_attr( $key ),
-				$this->esc_attr( $value )
-			);
 		}
 
 		return implode( ' ', $html );

--- a/src/View/Select.php
+++ b/src/View/Select.php
@@ -49,7 +49,7 @@ class Select implements RenderableElementInterface {
 		$html     = [];
 
 		foreach ( $list->get_choices() as $key => $name ) {
-			$html[] = sprintF(
+			$html[] = sprintf(
 				'<option value="%s" %s>%s</option>',
 				$this->esc_attr( $key ),
 				isset( $selected[ $key ] ) ? 'selected="selected"' : '',

--- a/tests/phpunit/Unit/Element/ElementTest.php
+++ b/tests/phpunit/Unit/Element/ElementTest.php
@@ -32,6 +32,7 @@ class ElementTest extends AbstractTestCase {
 		static::assertCount( 0, $testee->get_errors() );
 		static::assertFalse( $testee->has_errors() );
 		static::assertCount( 0, $testee->get_label_attributes() );
+		static::assertFalse( $testee->is_disabled() );
 	}
 
 	/**
@@ -135,13 +136,21 @@ class ElementTest extends AbstractTestCase {
 	/**
 	 * Basic test to check, if we can set and get a single option.
 	 */
-	public function set_get_option() {
+	public function test_set_get_option() {
 
 		$testee = new Element( 'id' );
 		$testee->set_option( 'foo', 'bar' );
 
 		static::assertSame( 'bar', $testee->get_option( 'foo' ) );
 		static::assertSame( [ 'foo' => 'bar' ], $testee->get_options() );
+		static::assertSame( '', $testee->get_option( 'undefined key' ) );
 	}
 
+	public function test_is_disabled() {
+
+		$testee = new Element( '' );
+		$testee->set_attribute( 'disabled', TRUE );
+
+		static::assertTrue( $testee->is_disabled() );
+	}
 }

--- a/tests/phpunit/Unit/Fixtures/ElementWithoutLabelAwareInterface.php
+++ b/tests/phpunit/Unit/Fixtures/ElementWithoutLabelAwareInterface.php
@@ -123,6 +123,12 @@ class ElementWithoutLabelAwareInterface implements ElementInterface {
 	 * @return int|string $value
 	 */
 	public function get_option( string $key ) {
-		// TODO: Implement get_option() method.
+
+		return $key;
+	}
+
+	public function is_disabled(): bool {
+
+		return FALSE;
 	}
 }

--- a/tests/phpunit/Unit/View/AttributeFormatterTraitTest.php
+++ b/tests/phpunit/Unit/View/AttributeFormatterTraitTest.php
@@ -1,0 +1,33 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace ChriCo\Fields\Tests\Unit\View;
+
+use ChriCo\Fields\View\AttributeFormatterTrait;
+
+class AttributeFormatterTraitTest extends AbstractViewTestCase {
+
+	/**
+	 * @dataProvider provide_get_attributes_as_string
+	 */
+	public function test_get_attributes_as_string( array $input, string $expected ) {
+
+		static::assertSame(
+			$expected,
+			/** @var AttributeFormatterTrait $testee */
+			$this->getMockForTrait( AttributeFormatterTrait::class )
+				->get_attributes_as_string( $input )
+		);
+	}
+
+	public function provide_get_attributes_as_string() {
+
+		return [
+			'empty attributes'   => [ [], '' ],
+			'string attributes'  => [ [ 'foo' => 'bar' ], 'foo="bar"' ],
+			'int attributes'     => [ [ 1 => 2 ], '1="2"' ],
+			'boolean attributes' => [ [ 'disabled' => TRUE, 'required' => FALSE ], 'disabled' ],
+			'array attributes'   => [ [ 'foo' => [ 'bar' => 'baz' ] ], 'foo="{"bar":"baz"}"' ]
+		];
+	}
+
+}


### PR DESCRIPTION
This pull is based on https://github.com/Chrico/wp-fields/pull/2 and introduces following new features:

- Added new tests for `AttributeFormatterTrait`.
- Implemented boolean-attributes like `disabled` or `required`.
- Introduced new method `is_disabled` to `ElementInterface`.
- Don't bind data to Elements or validate Elements which are disabled. 